### PR TITLE
Fix a BOZO mistake

### DIFF
--- a/docker-compose/plausible/docker-compose.yml
+++ b/docker-compose/plausible/docker-compose.yml
@@ -17,7 +17,6 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
     networks:
       - internal
-    restart: always
 
   plausible_events_db:
     image: yandex/clickhouse-server:latest


### PR DESCRIPTION
`restart: always` used twice which raises an error